### PR TITLE
Update README.md and Dockerfile for Ubuntu 23.10, GCC GFortran 13.2.0, and dependency package updates.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,21 @@
-FROM ubuntu:18.04
+FROM ubuntu:23.10
 
 ENV USERNAME=backus
 
 # install sudo
-RUN apt-get -yq update && apt-get -yq install sudo
+RUN apt-get -yq update && apt-get -yq install sudo 
 
 # create and switch to a user
 RUN echo "backus ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 RUN useradd --no-log-init --home-dir /home/$USERNAME --create-home --shell /bin/bash $USERNAME
-RUN adduser $USERNAME sudo
+RUN usermod -aG sudo $USERNAME
+#RUN adduser $USERNAME sudo
 USER $USERNAME
 WORKDIR /home/$USERNAME
 
 # install packages
 RUN sudo apt-get install -yq git curl && \
-    sudo apt-get install --no-install-recommends -yq make cmake gfortran libcoarrays-dev libopenmpi-dev open-coarrays-bin && \
+    sudo apt-get install --no-install-recommends -yq make cmake gfortran libcoarrays-dev libopenmpi-dev libcoarrays-openmpi-dev libcaf-openmpi-3&& \
     sudo apt-get clean -q
 
 # get modern-fortran code

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:23.10
 ENV USERNAME=backus
 
 # install sudo
-RUN apt-get -yq update && apt-get -yq install sudo 
+RUN apt-get -yq update && apt-get -yq install sudo
 
 # create and switch to a user
 RUN echo "backus ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # modern-fortran-docker
 
 Dockerfile to build a modern-fortran Docker image.
-It's based off Ubuntu 18.04 and installs gfortran, OpenMPI, and OpenCoarrays for you.
+It's based off Ubuntu 23.10, which has several enhancements to the Linux kernel and supports 
+GCC GFortran v13.2.0.
+
+This Dockerfile installs gfortran, OpenMPI, and OpenCoarrays for you.
 It will also git clone the modern-fortran projects.
 
-You will need Docker set up and running on your system.
+You will need Docker to be set up and running on your system.
 
 ## Build
 
@@ -29,3 +32,4 @@ docker run -it modern-fortran:latest /bin/bash
 ## Thanks
 
 Maurizio Tomassi who provided the original Dockerfile.
+Joshua Noorrid who updated the Dockerfile for use with Ubuntu 23.10

--- a/README.md
+++ b/README.md
@@ -31,5 +31,5 @@ docker run -it modern-fortran:latest /bin/bash
 
 ## Thanks
 
-Maurizio Tomassi who provided the original Dockerfile.
-Joshua Noorrid who updated the Dockerfile for use with Ubuntu 23.10
+* Maurizio Tomassi who provided the original Dockerfile
+* Joshua Norrid who updated the Dockerfile for use with Ubuntu 23.10


### PR DESCRIPTION
Hi - I have updated the Dockerfile for Ubuntu 23.10 and GCC GFortran 13.2.0. This provides users with a significant upgrade for the Linux kernel + Ubuntu distribution, the GFortran compiler, and all of the dependency packages, but it brings everything up to date for Modern Fortran users. Requires testing against each of the book's example repositories, but thought I would contribute this piece to help make the process of testing easier. Goal was to try and bring all of this up to date to support a more modern Linux version. Thanks! /JN